### PR TITLE
changes matcha/= matcher to pretty format the :expected value

### DIFF
--- a/src/matcha.clj
+++ b/src/matcha.clj
@@ -84,7 +84,7 @@
   [a]
   (make-record-matcher
     (fn [b] (core/= a b))
-    (pr-str a)
+    (pp a)
     (fn [x]
       (let [[things-in-a things-in-x things-in-both] (data/diff a x)]
         (str (describe-class-mismatch x)

--- a/test/matcha_test.clj
+++ b/test/matcha_test.clj
@@ -18,6 +18,15 @@
   (check-successful (matcha/= 1) 1)
   (check-failure (matcha/= 1) 0))
 
+(deftest =-pretty-prints-the-expected-value
+  (let [large-map {:one {:one {:one [1 2] :two [1 2]}
+                         :two {:one [1 2] :two [1 2]}}
+                   :two {:one {:one [1 2] :two [1 2]}
+                         :two {:one [1 2] :two [1 2]}}}
+        match-result (matcha/run-match (matcha/= large-map) {})]
+    (clojure.test/is (= (matcha/pp large-map)
+                        (:expected match-result)))))
+
 (deftest empty?-test
   (check-successful matcha/empty? [])
   (check-failure matcha/empty? [1]))


### PR DESCRIPTION
The `matcha/=` matcher renders the `:was` value using `matcha/pp` but renders
the `:expected` value using `clojure.core/pr-str`. This makes the output
inconsistent when comparing data structures large enough to cause `pp` to
insert newlines and indentation.

---

I noticed this while integrating matcha into a test framework I'm working on. Here's some example output that demonstrates the problem.

Current behavior:

```
  1) matcha/= expected value is difficult to compare to the actual value
     ===================================================================
     expected : {:one {:one [:one :two :three], :two [:one :two :three], :three {:one {:one [:one :two :three], :two [:one :two :three], :three [:one :two :three]}, :two {:one [:one :two :three], :two [:one :two :three], :three [:one :two :three]}, :three {:one [:one :two :three], :two [:one :two :three], :three [:one :two :three]}}}}
          got : {:one
                 {:one [:one :two :three],
                  :two [:one :two :three],
                  :three
                  {:one
                   {:one [:one :two :three],
                    :two [:one :two :three],
                    :three [:one :two :three]},
                   :two
                   {:one [:one :two :three],
                    :two [:one :two :three],
                    :three [:one :two :three]},
                   :three
                   {:one [:one :two :three],
                    :two [:one :two :three],
                    :three [:one :two :three]}}},
                 :foo "bar"}
                 <class clojure.lang.PersistentArrayMap>
                    diff:
                       +: nil

                       -: {:foo "bar"}
```

Desired behavior:

```
  1) matcha/= expected value is difficult to compare to the actual value
     ===================================================================
     expected : {:one
                 {:one [:one :two :three],
                  :two [:one :two :three],
                  :three
                  {:one
                   {:one [:one :two :three],
                    :two [:one :two :three],
                    :three [:one :two :three]},
                   :two
                   {:one [:one :two :three],
                    :two [:one :two :three],
                    :three [:one :two :three]},
                   :three
                   {:one [:one :two :three],
                    :two [:one :two :three],
                    :three [:one :two :three]}}}}
          got : {:one
                 {:one [:one :two :three],
                  :two [:one :two :three],
                  :three
                  {:one
                   {:one [:one :two :three],
                    :two [:one :two :three],
                    :three [:one :two :three]},
                   :two
                   {:one [:one :two :three],
                    :two [:one :two :three],
                    :three [:one :two :three]},
                   :three
                   {:one [:one :two :three],
                    :two [:one :two :three],
                    :three [:one :two :three]}}},
                 :foo "bar"}
                 <class clojure.lang.PersistentArrayMap>
                    diff:
                       +: nil

                       -: {:foo "bar"}
```
